### PR TITLE
Add linting and fromat checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches:
+      - "*"
+
+jobs:
+  Cancel-previous-jobs:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: khan/pull-request-workflow-cancel@1.0.0
+        with:
+          workflows: "main.yml"
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+
+
+  Formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Formatting
+        uses: github/super-linter@v3.15.2
+        env:
+          VALIDATE_ALL_CODEBASE: false
+          DEFAULT_BRANCH: master
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_SNAKEMAKE_SNAKEFMT: true
+
+
+  Linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lint workflow
+        uses: snakemake/snakemake-github-action@v1.15.0
+        with:
+          directory: .
+          snakefile: workflow/Snakefile
+          stagein: mamba install -n snakemake -c conda-forge peppy
+          args: "--lint"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ analysis/*
 !resources/*
 !workflow
 !workflow/**
+!.github
+!.github/**
 !.gitignore
 !.gitattributes
 !.editorconfig

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -8,7 +8,7 @@ pepfile: config["pepfile"]
 report: "report/workflow.rst"
 
 # Allow users to fix the underlying OS via singularity.
-singularity: "docker://continuumio/miniconda3"
+container: "docker://continuumio/miniconda3"
 
 
 # rule all:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -3,7 +3,7 @@ import pandas as pd
 
 # this container defines the underlying OS for each job when using the workflow
 # with --use-conda --use-singularity
-singularity: "docker://continuumio/miniconda3"
+container: "docker://continuumio/miniconda3"
 
 ##### load config and sample sheets #####
 


### PR DESCRIPTION
This PR introduces tests, that ensure proper linted and formated Snakemake code.

Use `snakemake --lint` locally, if linting fails.
Install `snakefmt` via `conda install -c bioconda snakefmt` and run `snakefmt workflow/` if formatting fails