### PR TITLE
Adjust to new input structure

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -25,6 +25,6 @@ include: "rules/post-processing.smk"
 # Subsequent target rules can be specified below. They should start with all_*.
 rule all:
     input:
-        expand("results/{id}/personal-data-summary.tsv", id=get_all_ids()),
-        expand("results/{id}/moved", id=get_all_ids()),
+        expand("results/{id}/tmp/personal-data-summary.tsv", id=get_all_ids()),
+        expand("results/{id}/tmp/moved", id=get_all_ids()),
         expand("results/{id}/plots/summary-for-{id}.svg", id=get_all_ids()),

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -26,5 +26,5 @@ include: "rules/post-processing.smk"
 rule all:
     input:
         expand("results/{id}/tmp/personal-data-summary.tsv", id=get_all_ids()),
-        expand("results/{id}/tmp/moved", id=get_all_ids()),
+        expand("results/{id}/tmp/deleted", id=get_all_ids()),
         expand("results/{id}/plots/summary-for-{id}.svg", id=get_all_ids()),

--- a/workflow/envs/unix.yaml
+++ b/workflow/envs/unix.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - anaconda
+dependencies:  
+  - unzip = 6.0

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -45,7 +45,7 @@ def get_image_paths_for_id(wildcards):
         for path in paths
         if ".snakemake" not in path and ".DS_Store" not in path
     ]
-    paths=[
+    paths = [
         path.removeprefix("results/{id}/uncompressed-zip-docs/".format(id=wildcards.id))
         for path in paths
     ]
@@ -149,7 +149,4 @@ def get_path_of_filename(wildcards):
 
 def get_uncompressed_image(wildcards):
     dir = get_uncompressed_docs_dir(wildcards)[0]
-    print(dir)
-    print(os.path.join(dir, wildcards.img))
     return os.path.join(dir, wildcards.img)
-

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -40,14 +40,14 @@ def get_image_paths_for_id(wildcards):
     with checkpoints.fix_file_ext.get(id=wildcards.id).output[0].open() as f:
         paths = pd.read_csv(f, sep="\n", header=None, squeeze=True)
 
+    # TODO
+    # This is ugly. We should rewrite the file handling.
     paths = [
-        path.removeprefix("results/{id}/uncompressed-lz4-docs/".format(id=wildcards.id))
+        path.removeprefix("results/{id}/tmp/uncompressed-lz4-docs/".format(id=wildcards.id))
         for path in paths
         if ".snakemake" not in path and ".DS_Store" not in path
     ]
 
-    # TODO
-    # This is ugly. We should rewrite the file handling.
     paths = [
         path.removeprefix(
             "results/{id}/tmp/uncompressed-zip-docs/".format(id=wildcards.id)

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -45,11 +45,13 @@ def get_image_paths_for_id(wildcards):
         for path in paths
         if ".snakemake" not in path and ".DS_Store" not in path
     ]
+
+    # TODO
+    # This is ugly. We should rewrite the file handling.
     paths = [
         path.removeprefix("results/{id}/uncompressed-zip-docs/".format(id=wildcards.id))
         for path in paths
     ]
-    print(paths)
     return paths
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -112,6 +112,32 @@ def get_questionable_imgs(wildcards, case):
             id=wildcards.id
         ).output.partly_found_name.open() as f:
             paths = load_tsv(f)
+    elif case == "all":
+        with checkpoints.create_paths_for_manually_checking.get(
+                id=wildcards.id
+            ).output.no_redaction.open() as f:
+                no_redaction = load_tsv(f)
+        with checkpoints.create_paths_for_manually_checking.get(
+                id=wildcards.id
+            ).output.high_degree_of_redaction.open() as f:
+                high_degree_of_redaction = load_tsv(f)
+        with checkpoints.create_paths_for_manually_checking.get(
+                id=wildcards.id
+            ).output.partly_found_address.open() as f:
+                partly_found_address = load_tsv(f)
+        with checkpoints.create_paths_for_manually_checking.get(
+                id=wildcards.id
+            ).output.partly_found_name.open() as f:
+                partly_found_name = load_tsv(f)
+        
+        all_paths = no_redaction.append(high_degree_of_redaction, ignore_index=True).append(partly_found_address, ignore_index=True).append(partly_found_name, ignore_index=True)
+        all_paths = all_paths.unique()
+        print("---------")
+        print(all_paths)
+        print("---------")
+        print("FUUUUUUUCK")
+        return all_paths
+
 
     paths = [
         path.replace("results/{id}/processed-docs/".format(id=wildcards.id), "")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -1,5 +1,6 @@
 from snakemake.utils import validate
 import pandas as pd
+from os import walk
 
 
 # this container defines the underlying OS for each job when using the workflow
@@ -117,3 +118,26 @@ def get_resource(name):
 def get_version():
     with open("resources/version.txt", "r") as v:
         return v.readline().replace("\n", "")
+
+
+def get_uncompressed_docs_dir(wildcards):
+    docs = get_compressed_docs(wildcards).values[0]
+    if docs.endswith(".docs"):
+        return ("results/{id}/uncompressed-zip-docs",)
+    elif docs.endswith(".tar.lz4"):
+        return ("results/{id}/uncompressed-lz4-docs",)
+
+
+def get_zip_files_in_dir(wildcards):
+    docs = get_compressed_docs(wildcards).values[0]
+    filenames = os.listdir(docs)
+    return [
+        filename.removesuffix(".zip")
+        for filename in filenames
+        if filename.endswith(".zip")
+    ]
+
+
+def get_path_of_filename(wildcards):
+    docs = get_compressed_docs(wildcards).values[0]
+    return os.path.join(docs, wildcards.filename + ".zip")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -49,7 +49,7 @@ def get_image_paths_for_id(wildcards):
     # TODO
     # This is ugly. We should rewrite the file handling.
     paths = [
-        path.removeprefix("results/{id}/uncompressed-zip-docs/".format(id=wildcards.id))
+        path.removeprefix("results/{id}/tmp/uncompressed-zip-docs/".format(id=wildcards.id))
         for path in paths
     ]
     return paths
@@ -63,7 +63,7 @@ def get_processed_pages(wildcards):
 
 def get_personal_data(wildcards):
     paths = get_image_paths_for_id(wildcards)
-    pattern = "results/{{id}}/data-to-redact/{img}.tsv"
+    pattern = "results/{{id}}/tmp/data-to-redact/{img}.tsv"
     return expand(pattern, img=paths)
 
 
@@ -129,9 +129,9 @@ def get_version():
 def get_uncompressed_docs_dir(wildcards):
     docs = get_compressed_docs(wildcards).values[0]
     if docs.endswith(".docs"):
-        return ("results/{id}/uncompressed-zip-docs",)
+        return ("results/{id}/tmp/uncompressed-zip-docs",)
     elif docs.endswith(".tar.lz4"):
-        return ("results/{id}/uncompressed-lz4-docs",)
+        return ("results/{id}/tmp/uncompressed-lz4-docs",)
 
 
 def get_zip_files_in_dir(wildcards):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -43,7 +43,9 @@ def get_image_paths_for_id(wildcards):
     # TODO
     # This is ugly. We should rewrite the file handling.
     paths = [
-        path.removeprefix("results/{id}/tmp/uncompressed-lz4-docs/".format(id=wildcards.id))
+        path.removeprefix(
+            "results/{id}/tmp/uncompressed-lz4-docs/".format(id=wildcards.id)
+        )
         for path in paths
         if ".snakemake" not in path and ".DS_Store" not in path
     ]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -41,7 +41,7 @@ def get_image_paths_for_id(wildcards):
         paths = pd.read_csv(f, sep="\n", header=None, squeeze=True)
 
     paths = [
-        path.removeprefix("results/{id}/uncompressed-docs/".format(id=wildcards.id))
+        path.removeprefix("results/{id}/uncompressed-lz4-docs/".format(id=wildcards.id))
         for path in paths
         if ".snakemake" not in path and ".DS_Store" not in path
     ]

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -49,7 +49,9 @@ def get_image_paths_for_id(wildcards):
     # TODO
     # This is ugly. We should rewrite the file handling.
     paths = [
-        path.removeprefix("results/{id}/tmp/uncompressed-zip-docs/".format(id=wildcards.id))
+        path.removeprefix(
+            "results/{id}/tmp/uncompressed-zip-docs/".format(id=wildcards.id)
+        )
         for path in paths
     ]
     return paths

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -41,11 +41,15 @@ def get_image_paths_for_id(wildcards):
         paths = pd.read_csv(f, sep="\n", header=None, squeeze=True)
 
     paths = [
-        path.replace("results/{id}/uncompressed-docs/".format(id=wildcards.id), "")
+        path.removeprefix("results/{id}/uncompressed-docs/".format(id=wildcards.id))
         for path in paths
         if ".snakemake" not in path and ".DS_Store" not in path
     ]
-
+    paths=[
+        path.removeprefix("results/{id}/uncompressed-zip-docs/".format(id=wildcards.id))
+        for path in paths
+    ]
+    print(paths)
     return paths
 
 
@@ -141,3 +145,11 @@ def get_zip_files_in_dir(wildcards):
 def get_path_of_filename(wildcards):
     docs = get_compressed_docs(wildcards).values[0]
     return os.path.join(docs, wildcards.filename + ".zip")
+
+
+def get_uncompressed_image(wildcards):
+    dir = get_uncompressed_docs_dir(wildcards)[0]
+    print(dir)
+    print(os.path.join(dir, wildcards.img))
+    return os.path.join(dir, wildcards.img)
+

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -130,16 +130,15 @@ def get_questionable_imgs(wildcards, case):
         ).output.partly_found_name.open() as f:
             partly_found_name = load_tsv(f)
 
+        all_paths= pd.Series("results/{id}/tmp/filler".format(id=wildcards.id))
         all_paths = (
-            no_redaction.append(high_degree_of_redaction, ignore_index=True)
+            all_paths.append(no_redaction, ignore_index=True)
+            .append(high_degree_of_redaction, ignore_index=True)
             .append(partly_found_address, ignore_index=True)
             .append(partly_found_name, ignore_index=True)
         )
         all_paths = all_paths.unique()
-        print("---------")
-        print(all_paths)
-        print("---------")
-        print("FUUUUUUUCK")
+
         return all_paths
 
     paths = [

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -114,30 +114,33 @@ def get_questionable_imgs(wildcards, case):
             paths = load_tsv(f)
     elif case == "all":
         with checkpoints.create_paths_for_manually_checking.get(
-                id=wildcards.id
-            ).output.no_redaction.open() as f:
-                no_redaction = load_tsv(f)
+            id=wildcards.id
+        ).output.no_redaction.open() as f:
+            no_redaction = load_tsv(f)
         with checkpoints.create_paths_for_manually_checking.get(
-                id=wildcards.id
-            ).output.high_degree_of_redaction.open() as f:
-                high_degree_of_redaction = load_tsv(f)
+            id=wildcards.id
+        ).output.high_degree_of_redaction.open() as f:
+            high_degree_of_redaction = load_tsv(f)
         with checkpoints.create_paths_for_manually_checking.get(
-                id=wildcards.id
-            ).output.partly_found_address.open() as f:
-                partly_found_address = load_tsv(f)
+            id=wildcards.id
+        ).output.partly_found_address.open() as f:
+            partly_found_address = load_tsv(f)
         with checkpoints.create_paths_for_manually_checking.get(
-                id=wildcards.id
-            ).output.partly_found_name.open() as f:
-                partly_found_name = load_tsv(f)
-        
-        all_paths = no_redaction.append(high_degree_of_redaction, ignore_index=True).append(partly_found_address, ignore_index=True).append(partly_found_name, ignore_index=True)
+            id=wildcards.id
+        ).output.partly_found_name.open() as f:
+            partly_found_name = load_tsv(f)
+
+        all_paths = (
+            no_redaction.append(high_degree_of_redaction, ignore_index=True)
+            .append(partly_found_address, ignore_index=True)
+            .append(partly_found_name, ignore_index=True)
+        )
         all_paths = all_paths.unique()
         print("---------")
         print(all_paths)
         print("---------")
         print("FUUUUUUUCK")
         return all_paths
-
 
     paths = [
         path.replace("results/{id}/processed-docs/".format(id=wildcards.id), "")

--- a/workflow/rules/extract-data.smk
+++ b/workflow/rules/extract-data.smk
@@ -59,6 +59,7 @@ rule scan_decomp_dir:
     script:
         "../scripts/scan_decomp_data.py"
 
+
 # TODO combine this rule with the rule scan_decomp_dir
 checkpoint fix_file_ext:
     input:

--- a/workflow/rules/extract-data.smk
+++ b/workflow/rules/extract-data.smk
@@ -1,3 +1,14 @@
+rule extract_personal_data:
+    input:
+        get_fhir_metadata,
+    output:
+        "results/{id}/personal-data.json",
+    log:
+        "logs/{id}/extract_personal_data.log",
+    script:
+        "../scripts/extract-personal-data.py"
+
+
 rule extract_lz4_docs:
     input:
         get_compressed_docs,
@@ -58,14 +69,3 @@ checkpoint fix_file_ext:
         "logs/{id}/fix_file_ext.log",
     script:
         "../scripts/fix_filenames.py"
-
-
-rule extract_personal_data:
-    input:
-        get_fhir_metadata,
-    output:
-        "results/{id}/personal-data.json",
-    log:
-        "logs/{id}/extract_personal_data.log",
-    script:
-        "../scripts/extract-personal-data.py"

--- a/workflow/rules/extract-data.smk
+++ b/workflow/rules/extract-data.smk
@@ -2,7 +2,7 @@ rule extract_personal_data:
     input:
         get_fhir_metadata,
     output:
-        "results/{id}/personal-data.json",
+        temp("results/{id}/tmp/personal-data.json"),
     log:
         "logs/{id}/extract_personal_data.log",
     script:
@@ -13,7 +13,7 @@ rule extract_lz4_docs:
     input:
         get_compressed_docs,
     output:
-        directory("results/{id}/uncompressed-lz4-docs"),
+        directory("results/{id}/tmp/uncompressed-lz4-docs"),
     log:
         "logs/{id}/extract_lz4_docs.log",
     shell:
@@ -24,7 +24,7 @@ rule extract_zipped_doc:
     input:
         get_path_of_filename,
     output:
-        temp(directory("results/{id}/single-uncompressed-zip-docs/{filename}")),
+        temp(directory("results/{id}/tmp/single-uncompressed-zip-docs/{filename}")),
     log:
         "logs/{id}/extract_zip/{filename}.log",
     conda:
@@ -36,11 +36,11 @@ rule extract_zipped_doc:
 rule extract_all_zipped_docs:
     input:
         lambda wildcards: expand(
-            "results/{{id}}/single-uncompressed-zip-docs/{filename}",
+            "results/{{id}}/tmp/single-uncompressed-zip-docs/{filename}",
             filename=get_zip_files_in_dir(wildcards),
         ),
     output:
-        directory("results/{id}/uncompressed-zip-docs/"),
+        directory("results/{id}/tmp/uncompressed-zip-docs/"),
     params:
         in_dir=lambda w, input: os.path.dirname(input[0]),
     log:
@@ -53,18 +53,19 @@ rule scan_decomp_dir:
     input:
         get_uncompressed_docs_dir,
     output:
-        "results/{id}/file_paths.csv",
+        temp("results/{id}/tmp/file_paths.csv"),
     log:
         "logs/{id}/scan_decomp_dir.log",
     script:
         "../scripts/scan_decomp_data.py"
 
-
+# TODO combine this rule with the rule scan_decomp_dir
 checkpoint fix_file_ext:
     input:
-        "results/{id}/file_paths.csv",
+        files="results/{id}/tmp/file_paths.csv",
+        dirs=get_uncompressed_docs_dir,
     output:
-        "results/{id}/fixed_paths.csv",
+        temp("results/{id}/tmp/fixed_paths.csv"),
     log:
         "logs/{id}/fix_file_ext.log",
     script:

--- a/workflow/rules/extract-data.smk
+++ b/workflow/rules/extract-data.smk
@@ -19,7 +19,7 @@ rule extract_zipped_doc:
     conda:
         "../envs/unix.yaml"
     shell:
-        "(unzip \"{input}\" -d \"{output}\") > \"{log}\" 2>&1"
+        '(unzip "{input}" -d "{output}") > "{log}" 2>&1'
 
 
 rule extract_all_zipped_docs:
@@ -31,7 +31,7 @@ rule extract_all_zipped_docs:
     output:
         directory("results/{id}/uncompressed-zip-docs/"),
     params:
-        in_dir = lambda w, input: os.path.dirname(input[0])
+        in_dir=lambda w, input: os.path.dirname(input[0]),
     log:
         "logs/{id}/extract_zip/all.log",
     shell:

--- a/workflow/rules/post-processing.smk
+++ b/workflow/rules/post-processing.smk
@@ -97,6 +97,7 @@ rule copy_questionable_imgs:
         lambda wildcards: get_questionable_imgs(wildcards, case="partly_found_name"),
     output:
         temp(touch("results/{id}/tmp/moved")),
+        touch("results/{id}/tmp/filler")
     log:
         "logs/{id}/move_questionable_imgs.log",
 

--- a/workflow/rules/post-processing.smk
+++ b/workflow/rules/post-processing.smk
@@ -101,6 +101,18 @@ rule copy_questionable_imgs:
         "logs/{id}/move_questionable_imgs.log",
 
 
+rule remove_questionable_imgs:
+    input:
+        paths = lambda wildcards: get_questionable_imgs(wildcards, case="all"),
+        moved="results/{id}/tmp/moved",
+    output:
+        temp(touch("results/{id}/tmp/deleted")),
+    log:
+        "logs/{id}/remove_questionable_imgs"
+    shell:
+        "(rm {input.paths}) 2> {log}"
+
+
 rule summarize_manuel_checks:
     input:
         manuel_checks=rules.create_paths_for_manually_checking.output,

--- a/workflow/rules/post-processing.smk
+++ b/workflow/rules/post-processing.smk
@@ -24,7 +24,7 @@ checkpoint create_paths_for_manually_checking:
         "../scripts/create-paths-for-manually-checking.py"
 
 
-rule mv_no_redaction:
+rule cp_no_redaction:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -37,10 +37,10 @@ rule mv_no_redaction:
     log:
         "logs/{id}/cp_no_redaction/{img}.log",
     shell:
-        "(mv '{input}' '{output}') 2> '{log}'"
+        "(cp '{input}' '{output}') 2> '{log}'"
 
 
-rule mv_high_degree_of_redaction:
+rule cp_high_degree_of_redaction:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -53,10 +53,10 @@ rule mv_high_degree_of_redaction:
     log:
         "logs/{id}/cp_high_degree_of_redaction/{img}.log",
     shell:
-        "(mv '{input}' '{output}') 2> '{log}'"
+        "(cp '{input}' '{output}') 2> '{log}'"
 
 
-rule mv_partly_found_address:
+rule cp_partly_found_address:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -69,10 +69,10 @@ rule mv_partly_found_address:
     log:
         "logs/{id}/cp_partly_found_address/{img}.log",
     shell:
-        "(mv '{input}' '{output}') 2> '{log}'"
+        "(cp '{input}' '{output}') 2> '{log}'"
 
 
-rule mv_partly_found_name:
+rule cp_partly_found_name:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -84,10 +84,10 @@ rule mv_partly_found_name:
     log:
         "logs/{id}/cp_partly_found_name/{img}.log",
     shell:
-        "(mv '{input}' '{output}') 2> '{log}'"
+        "(cp '{input}' '{output}') 2> '{log}'"
 
 
-rule move_questionable_imgs:
+rule copy_questionable_imgs:
     input:
         lambda wildcards: get_questionable_imgs(wildcards, case="no_redaction"),
         lambda wildcards: get_questionable_imgs(

--- a/workflow/rules/post-processing.smk
+++ b/workflow/rules/post-processing.smk
@@ -3,7 +3,7 @@ rule summarize_found_personal_data:
         data=get_personal_data,
         pages=get_processed_pages,
     output:
-        "results/{id}/personal-data-summary.tsv",
+        temp("results/{id}/tmp/personal-data-summary.tsv"),
     log:
         "logs/{id}/summarize_found_personal_data.log",
     script:
@@ -12,7 +12,7 @@ rule summarize_found_personal_data:
 
 checkpoint create_paths_for_manually_checking:
     input:
-        "results/{id}/personal-data-summary.tsv",
+        "results/{id}/tmp/personal-data-summary.tsv",
     output:
         no_redaction="results/{id}/no-redaction.tsv",
         high_degree_of_redaction="results/{id}/high-degree-of-redaction.tsv",
@@ -24,7 +24,7 @@ checkpoint create_paths_for_manually_checking:
         "../scripts/create-paths-for-manually-checking.py"
 
 
-rule cp_no_redaction:
+rule mv_no_redaction:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -37,10 +37,10 @@ rule cp_no_redaction:
     log:
         "logs/{id}/cp_no_redaction/{img}.log",
     shell:
-        "(cp '{input}' '{output}') 2> '{log}'"
+        "(mv '{input}' '{output}') 2> '{log}'"
 
 
-rule cp_high_degree_of_redaction:
+rule mv_high_degree_of_redaction:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -53,10 +53,10 @@ rule cp_high_degree_of_redaction:
     log:
         "logs/{id}/cp_high_degree_of_redaction/{img}.log",
     shell:
-        "(cp '{input}' '{output}') 2> '{log}'"
+        "(mv '{input}' '{output}') 2> '{log}'"
 
 
-rule cp_partly_found_address:
+rule mv_partly_found_address:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -69,10 +69,10 @@ rule cp_partly_found_address:
     log:
         "logs/{id}/cp_partly_found_address/{img}.log",
     shell:
-        "(cp '{input}' '{output}') 2> '{log}'"
+        "(mv '{input}' '{output}') 2> '{log}'"
 
 
-rule cp_partly_found_name:
+rule mv_partly_found_name:
     input:
         "results/{id}/processed-docs/{img}",
     output:
@@ -84,7 +84,7 @@ rule cp_partly_found_name:
     log:
         "logs/{id}/cp_partly_found_name/{img}.log",
     shell:
-        "(cp '{input}' '{output}') 2> '{log}'"
+        "(mv '{input}' '{output}') 2> '{log}'"
 
 
 rule move_questionable_imgs:
@@ -96,7 +96,7 @@ rule move_questionable_imgs:
         lambda wildcards: get_questionable_imgs(wildcards, case="partly_found_address"),
         lambda wildcards: get_questionable_imgs(wildcards, case="partly_found_name"),
     output:
-        touch("results/{id}/moved"),
+        temp(touch("results/{id}/tmp/moved")),
     log:
         "logs/{id}/move_questionable_imgs.log",
 
@@ -104,9 +104,9 @@ rule move_questionable_imgs:
 rule summarize_manuel_checks:
     input:
         manuel_checks=rules.create_paths_for_manually_checking.output,
-        total_imgs_processed="results/{id}/personal-data-summary.tsv",
+        total_imgs_processed="results/{id}/tmp/personal-data-summary.tsv",
     output:
-        "results/{id}/manuel_check_summary.tsv",
+        "results/{id}/tabels/manuel_check_summary.tsv",
     log:
         "logs/{id}/summarize_manuel_checks.log",
     script:
@@ -115,7 +115,7 @@ rule summarize_manuel_checks:
 
 rule plot_manuel_check_summary:
     input:
-        "results/{id}/manuel_check_summary.tsv",
+        "results/{id}/tabels/manuel_check_summary.tsv",
     output:
         report(
             "results/{id}/plots/summary-for-{id}.svg",

--- a/workflow/rules/post-processing.smk
+++ b/workflow/rules/post-processing.smk
@@ -14,10 +14,10 @@ checkpoint create_paths_for_manually_checking:
     input:
         "results/{id}/tmp/personal-data-summary.tsv",
     output:
-        no_redaction="results/{id}/no-redaction.tsv",
-        high_degree_of_redaction="results/{id}/high-degree-of-redaction.tsv",
-        partly_found_address="results/{id}/partly-found-address.tsv",
-        partly_found_name="results/{id}/partly-found-name.tsv",
+        no_redaction="results/{id}/tabels/no-redaction.tsv",
+        high_degree_of_redaction="results/{id}/tabels/high-degree-of-redaction.tsv",
+        partly_found_address="results/{id}/tabels/partly-found-address.tsv",
+        partly_found_name="results/{id}/tabels/partly-found-name.tsv",
     log:
         "logs/{id}/create_paths_for_manually_checking.log",
     script:
@@ -106,7 +106,7 @@ rule summarize_manuel_checks:
         manuel_checks=rules.create_paths_for_manually_checking.output,
         total_imgs_processed="results/{id}/tmp/personal-data-summary.tsv",
     output:
-        "results/{id}/tabels/manuel_check_summary.tsv",
+        "results/{id}/tabels/manuel-check-summary.tsv",
     log:
         "logs/{id}/summarize_manuel_checks.log",
     script:
@@ -115,7 +115,7 @@ rule summarize_manuel_checks:
 
 rule plot_manuel_check_summary:
     input:
-        "results/{id}/tabels/manuel_check_summary.tsv",
+        "results/{id}/tabels/manuel-check-summary.tsv",
     output:
         report(
             "results/{id}/plots/summary-for-{id}.svg",

--- a/workflow/rules/post-processing.smk
+++ b/workflow/rules/post-processing.smk
@@ -103,12 +103,12 @@ rule copy_questionable_imgs:
 
 rule remove_questionable_imgs:
     input:
-        paths = lambda wildcards: get_questionable_imgs(wildcards, case="all"),
+        paths=lambda wildcards: get_questionable_imgs(wildcards, case="all"),
         moved="results/{id}/tmp/moved",
     output:
         temp(touch("results/{id}/tmp/deleted")),
     log:
-        "logs/{id}/remove_questionable_imgs"
+        "logs/{id}/remove_questionable_imgs",
     shell:
         "(rm {input.paths}) 2> {log}"
 

--- a/workflow/rules/process-data.smk
+++ b/workflow/rules/process-data.smk
@@ -17,7 +17,7 @@ rule identify_personal_data:
         personal_data="results/{id}/tmp/personal-data.json",
     output:
         text_to_redact=temp("results/{id}/tmp/data-to-redact/{img}.tsv"),
-        all_text="results/{id}/detected-text/{img}.tsv",
+        all_text="results/{id}/tmp/detected-text/{img}.tsv",
     log:
         "logs/{id}/identify-personal-data/{img}.log",
     conda:

--- a/workflow/rules/process-data.smk
+++ b/workflow/rules/process-data.smk
@@ -2,7 +2,7 @@ rule preprocess_page:
     input:
         get_uncompressed_image,
     output:
-        "results/{id}/preprocessed-docs/{img}",
+        temp("results/{id}/tmp/preprocessed-docs/{img}"),
     log:
         "logs/{id}/preprocess-page/{img}.log",
     conda:
@@ -13,10 +13,10 @@ rule preprocess_page:
 
 rule identify_personal_data:
     input:
-        preprocessed_page="results/{id}/preprocessed-docs/{img}",
-        personal_data="results/{id}/personal-data.json",
+        preprocessed_page="results/{id}/tmp/preprocessed-docs/{img}",
+        personal_data="results/{id}/tmp/personal-data.json",
     output:
-        text_to_redact="results/{id}/data-to-redact/{img}.tsv",
+        text_to_redact=temp("results/{id}/tmp/data-to-redact/{img}.tsv"),
         all_text="results/{id}/detected-text/{img}.tsv",
     log:
         "logs/{id}/identify-personal-data/{img}.log",
@@ -29,7 +29,7 @@ rule identify_personal_data:
 rule redact_page:
     input:
         orginal_page=get_uncompressed_image,
-        data_to_redact="results/{id}/data-to-redact/{img}.tsv",
+        data_to_redact="results/{id}/tmp/data-to-redact/{img}.tsv",
     output:
         "results/{id}/processed-docs/{img}",
     params:

--- a/workflow/rules/process-data.smk
+++ b/workflow/rules/process-data.smk
@@ -17,7 +17,7 @@ rule identify_personal_data:
         personal_data="results/{id}/tmp/personal-data.json",
     output:
         text_to_redact=temp("results/{id}/tmp/data-to-redact/{img}.tsv"),
-        all_text="results/{id}/tmp/detected-text/{img}.tsv",
+        all_text=temp("results/{id}/tmp/detected-text/{img}.tsv"),
     log:
         "logs/{id}/identify-personal-data/{img}.log",
     conda:

--- a/workflow/rules/process-data.smk
+++ b/workflow/rules/process-data.smk
@@ -1,6 +1,6 @@
 rule preprocess_page:
     input:
-        "results/{id}/uncompressed-docs/{img}",
+        get_uncompressed_image,
     output:
         "results/{id}/preprocessed-docs/{img}",
     log:
@@ -28,7 +28,7 @@ rule identify_personal_data:
 
 rule redact_page:
     input:
-        orginal_page="results/{id}/uncompressed-docs/{img}",
+        orginal_page=get_uncompressed_image,
         data_to_redact="results/{id}/data-to-redact/{img}.tsv",
     output:
         "results/{id}/processed-docs/{img}",

--- a/workflow/scripts/extract-personal-data.py
+++ b/workflow/scripts/extract-personal-data.py
@@ -106,7 +106,6 @@ def variate_personal_data(personal_data: dict, first_name_count: int) -> default
         personal_data[f"birthDate_perm{i}"] = f"*{dy}{sep}{m}{sep}{yr}"
         personal_data[f"birthDate_perm{i}{i}"] = f"{yr}{sep}{m}{sep}{dy}"
     
-    print(personal_data)
     #variate country
 
     return personal_data

--- a/workflow/scripts/extract-personal-data.py
+++ b/workflow/scripts/extract-personal-data.py
@@ -20,6 +20,14 @@ def parse_meta_data(json_path: str) -> defaultdict:
     with open(json_path) as json_file:
         data = json.load(json_file)
 
+    # select the patient reosurce from the bundel data export
+    for ele in data.get("entry", {}):
+        # iterate of entries
+        for key, value in ele.get("resource", {}).items():
+            if key == "resourceType" and value == "Patient":
+                data = ele.get("resource")
+                break
+
     # TODO design this part more flexible, maybe via the snakemake config file
     # ---------------------------------------
     personal_data = defaultdict()
@@ -32,9 +40,9 @@ def parse_meta_data(json_path: str) -> defaultdict:
     personal_data["address"] = data.get("address")[0].get("line")[0]
     personal_data["city"] = " ".join([data.get("address")[0].get("postalCode"), data.get("address")[0].get("city")])
     personal_data["case_number"] = json_path.split("/")[-1].split(".")[0]
-    for com in data["telecom"]:
-        com_type = com["system"]
-        personal_data[com_type] = com["value"]
+    for com in data.get("telecom", {}):
+        com_type = com.get("system", {})
+        personal_data[com_type] = com.get("value", {})
     # personal_data["gender"] = data.get("gender")
     # personal_data["country"] = data.get("address")[0].get("country")
     # ---------------------------------------
@@ -73,7 +81,7 @@ def variate_personal_data(personal_data: dict, first_name_count: int) -> default
                 provider_local_codes.append("0" + line.split(";")[0])
     
     nums = ["1","2","3","4","5","6","7","8","9","0"]
-    tmp_phone = personal_data["phone"]
+    tmp_phone = personal_data.get("phone", "")
     for letter in tmp_phone:
         if letter not in nums:
             tmp_phone = personal_data["phone"].replace(letter, "")

--- a/workflow/scripts/fix_filenames.py
+++ b/workflow/scripts/fix_filenames.py
@@ -37,4 +37,4 @@ def add_ext(paths_file: str, fixed_paths: str):
 
 if __name__ == "__main__":
     sys.stderr = open(snakemake.log[0], "w")
-    add_ext(snakemake.input[0], snakemake.output[0])
+    add_ext(snakemake.input.files, snakemake.output[0])


### PR DESCRIPTION
This PR
- integrates the newer zip folder structure and
- changes the output structure of the workflow. See [Snakemake Protected and Temporary Files](https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#protected-and-temporary-files) for more information and
- removes images, that have to be checked manually from the processed docs directory.